### PR TITLE
Fix output bytes

### DIFF
--- a/balloon.go
+++ b/balloon.go
@@ -52,8 +52,8 @@ func (cow *Cow) Balloon() string {
 		maxWidth = width
 	}
 
-	top := make([]byte, maxWidth+2)
-	bottom := make([]byte, maxWidth+2)
+	top := make([]byte, 0, maxWidth+2)
+	bottom := make([]byte, 0, maxWidth+2)
 
 	borderType := cow.borderType()
 


### PR DESCRIPTION
make([]byte, n) makes fixed buffer. So append() grow-up the bytes

before
![image](https://user-images.githubusercontent.com/10111/74581158-8ed01100-4fef-11ea-9b3c-9e4cd62b4660.png)
after
![image](https://user-images.githubusercontent.com/10111/74581168-ac04df80-4fef-11ea-92c3-36f9caf7eff9.png)
