### PR TITLE
Add scoop installation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ func main() {
 
 ## Install
 
+### Windows users via Scoop
+
+    $ scoop install neo-cowsay
+
 ### Mac and Linux users via Homebrew
 
     $ brew update


### PR DESCRIPTION
I just added  [`neo-cowsay`](https://github.com/ScoopInstaller/Main/blob/master/bucket/neo-cowsay.json) to scoop and it would be nice to have an installation reference to it.